### PR TITLE
Post slack messages "as user"

### DIFF
--- a/slack_progress/__init__.py
+++ b/slack_progress/__init__.py
@@ -12,7 +12,8 @@ class SlackProgress(object):
         params:
          - total(int): total number of items
         """
-        res = self.slack.chat.post_message(self.channel, self._makebar(0))
+        res = self.slack.chat.post_message(self.channel, self._makebar(0), 
+                                           as_user=True)
         bar = ProgressBar(self, total)
         bar.msg_ts = res.body['ts']
         bar.channel_id = res.body['channel']


### PR DESCRIPTION
Pass the "as_user" parameter to the underlying Slack API.  This allows the bot to show up as the named bot instead of as just `bot`.

<img width="448" alt="screen shot 2017-11-01 at 8 18 01 am" src="https://user-images.githubusercontent.com/59497/32281850-3e838e02-bedd-11e7-8668-4dbe3c1a1393.png">

In the picture the 8:15 message has the `as_user` change.