### PR TITLE
Feature/add log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,12 @@ pbar.pos = 100
 time.sleep(1)
 ```
 
+You can add logging messages too:
+```python
+pbar.pos = 50
+pbar.log("Step 1 complete")
+pbar.pos = 100
+pbar.log("Step 2 complete")
+```
+
 [screencap]: http://i.imgur.com/103z4Io.gif "slack-progress"

--- a/slack_progress/__init__.py
+++ b/slack_progress/__init__.py
@@ -71,12 +71,12 @@ class ProgressBar(object):
     def pos(self, val):
         if val != self._pos:
             self._pos = val
-            self.update()
+            self._update()
 
     def log(self, msg):
         timestamp = time.strftime('%X')  # returns HH:MM:SS time
         self._msg_log.append('*{}* - [{}]'.format(timestamp, msg))
-        self.update()
+        self._update()
 
-    def update(self):
+    def _update(self):
         self._sp._update(self.channel_id, self.msg_ts, self._pos, self._msg_log)

--- a/slack_progress/__init__.py
+++ b/slack_progress/__init__.py
@@ -33,10 +33,9 @@ class SlackProgress(object):
             bar.done = idx
 
     def _update(self, chan, msg_ts, pos, msg_log):
-        text = list(msg_log)
-        text.insert(0, self._makebar(pos))
-        text = '\n'.join(text)
-        self.slack.chat.update(chan, msg_ts, text)
+        content = [self._makebar(pos)] + msg_log
+        content = '\n'.join(content)
+        self.slack.chat.update(chan, msg_ts, content)
 
     def _makebar(self, pos):
         bar = (round(pos / 5) * chr(9608))

--- a/slack_progress/__init__.py
+++ b/slack_progress/__init__.py
@@ -72,9 +72,12 @@ class ProgressBar(object):
     def pos(self, val):
         if val != self._pos:
             self._pos = val
-            self._sp._update(self.channel_id, self.msg_ts, self._pos, self._msg_log)
+            self.update()
 
     def log(self, msg):
-        timestamp = time.strftime('%X - ')  # returns HH:MM:SS time
-        self._msg_log.append(timestamp + msg)
+        timestamp = time.strftime('%X')  # returns HH:MM:SS time
+        self._msg_log.append('*{}* - [{}]'.format(timestamp, msg))
+        self.update()
+
+    def update(self):
         self._sp._update(self.channel_id, self.msg_ts, self._pos, self._msg_log)

--- a/slack_progress/__init__.py
+++ b/slack_progress/__init__.py
@@ -1,4 +1,7 @@
+import time
+
 from slacker import Slacker
+
 
 class SlackProgress(object):
     def __init__(self, token, channel, suffix='%'):
@@ -29,12 +32,16 @@ class SlackProgress(object):
             yield(item)
             bar.done = idx
 
-    def _update(self, chan, msg_ts, pos):
-        self.slack.chat.update(chan, msg_ts, self._makebar(pos))
+    def _update(self, chan, msg_ts, pos, msg_log):
+        text = list(msg_log)
+        text.insert(0, self._makebar(pos))
+        text = '\n'.join(text)
+        self.slack.chat.update(chan, msg_ts, text)
 
     def _makebar(self, pos):
         bar = (round(pos / 5) * chr(9608))
         return '{} {}{}'.format(bar, pos, self.suffix)
+
 
 class ProgressBar(object):
 
@@ -46,6 +53,7 @@ class ProgressBar(object):
         self._pos = 0
         self._done = 0
         self.total = total
+        self._msg_log = []
 
     @property
     def done(self):
@@ -63,5 +71,10 @@ class ProgressBar(object):
     @pos.setter
     def pos(self, val):
         if val != self._pos:
-            self._sp._update(self.channel_id, self.msg_ts, val)
             self._pos = val
+            self._sp._update(self.channel_id, self.msg_ts, self._pos, self._msg_log)
+
+    def log(self, msg):
+        timestamp = time.strftime('%X - ')  # returns HH:MM:SS time
+        self._msg_log.append(timestamp + msg)
+        self._sp._update(self.channel_id, self.msg_ts, self._pos, self._msg_log)


### PR DESCRIPTION
Add the ability to add text logging below the progress bar. If it's not used, the bar functions as it always has. When `ProgressBar.log()` is called, a new message is appended to the progress logs. The progress bar is great, but it doesn't give any information about what it's doing.

e.g. 
```python
sp = SlackProgress(token='', channel='')
p = sp.new()
p.pos += 25
p.log('Process started')
time.sleep(1)
p.pos += 25
p.log('Step 1 building')
time.sleep(1)
p.pos += 25
p.log('Step 2 done')
time.sleep(1)
p.pos += 25
p.log('Done!')
```

Results in 

![screen shot 2018-08-29 at 11 37 17 am](https://user-images.githubusercontent.com/5453928/44799420-e2436a80-ab81-11e8-8ea9-e9d38e34e144.png)